### PR TITLE
Clean default printouts 

### DIFF
--- a/framework/fun4all/Fun4AllServer.cc
+++ b/framework/fun4all/Fun4AllServer.cc
@@ -861,7 +861,9 @@ int Fun4AllServer::BeginRun(const int runno)
     cout << "from your macro" << endl;
   }
   // print out all node trees
+#ifdef _DEBUG_ON
   Print("NODETREE");
+#endif
   return 0;
 }
 

--- a/packages/PHField/PHFieldConfig_v3.cc
+++ b/packages/PHField/PHFieldConfig_v3.cc
@@ -35,10 +35,12 @@ PHFieldConfig_v3::PHFieldConfig_v3(
 {
   if(filename1_.find("INVALID") == string::npos)  //suppress output when default ctor is called
   {
+#ifdef _DEBUG_ON
     cout << "PHFieldConfig_v3::PHFieldConfig_v3:" << endl;
     cout << " from file1 [" << filename1 << "]" << endl;
     cout << "  and file2 [" << filename2 << "]" << endl;
     cout << "scale1: " << setprecision(5) << scale1_ << ", scale2: " << setprecision(5) << scale2_ << ", targetmag_y: " << _taregetmag_y << endl;
+#endif
   }
 }
 
@@ -58,6 +60,7 @@ PHFieldConfig_v3::clone() const
  */
 void PHFieldConfig_v3::identify(std::ostream& os) const
 {
+#ifdef _DEBUG_ON
   os << "PHFieldConfig_v3::identify -";
   if (isValid())
   {
@@ -70,6 +73,7 @@ void PHFieldConfig_v3::identify(std::ostream& os) const
   else
     os << "Empty";
   os << endl;
+#endif
 }
 /// Clear Event
 void PHFieldConfig_v3::Reset()

--- a/packages/PHField/PHFieldRegionalConst.cc
+++ b/packages/PHField/PHFieldRegionalConst.cc
@@ -18,7 +18,9 @@ PHFieldRegionalConst::PHFieldRegionalConst(const double field, const double magf
 		_maxr(6.*cm), _minr(-0.1*cm),
 		_field_val(field*tesla)
 {
+#ifdef _DEBUG_O
 	identify();
+#endif
 }
 
 void PHFieldRegionalConst::GetFieldValue(const double point[4], double *Bfield ) const

--- a/packages/PHField/PHFieldUtility.cc
+++ b/packages/PHField/PHFieldUtility.cc
@@ -45,8 +45,10 @@ PHFieldUtility::BuildFieldMap(const PHFieldConfig *field_config, const int verbo
 
   if (verbosity)
   {
+#ifdef _DEBUG_ON
     cout << "PHFieldUtility::BuildFieldMap - construction field with configuration: ";
     field_config->identify();
+#endif
   }
 
   PHField *field(nullptr);

--- a/packages/PHField/SQField3DCartesian.cc
+++ b/packages/PHField/SQField3DCartesian.cc
@@ -26,11 +26,12 @@ SQField3DCartesian::SQField3DCartesian(const std::string& fname, const float mag
   , ystepsize(-1.)
   , zstepsize(-1.)
 {
+#ifdef _DEBUG_ON
   std::cout << "\n================ Begin Construct Mag Field =====================" << std::endl;
   std::cout << "\n-----------------------------------------------------------"
             << "\n      Magnetic field Module - Verbosity:"
             << "\n-----------------------------------------------------------\n";
-
+#endif
   //load from input file first
   fpoints.clear();
   if(filename.find(".root") != std::string::npos) 
@@ -41,8 +42,9 @@ SQField3DCartesian::SQField3DCartesian(const std::string& fname, const float mag
       std::cout << "SQField3DCartesian: cannot find the input ROOT field map, abort " << filename << std::endl;
       exit(EXIT_FAILURE);
     }
+#ifdef _DEBUG_ON
     std::cout << "SQField3DCartesian: loading field map from ROOT file " << filename << std::endl;
-
+#endif
     float x, y, z, Bx, By, Bz;
     TTree* inputTree = (TTree*)inputFile->Get("fieldmap");
     inputTree->SetBranchAddress("x", &x);
@@ -78,8 +80,9 @@ SQField3DCartesian::SQField3DCartesian(const std::string& fname, const float mag
       std::cout << "SQField3DCartesian: cannot find the input ASCII field map, abort " << filename << std::endl;
       exit(EXIT_FAILURE);
     }
+#ifdef _DEBUG_ON
     std::cout << "SQField3DCartesian: loading field map from ASCII file " << filename << std::endl;
-
+#endif
     std::string line;
     getline(fin, line);  //header line
     while(getline(fin, line))
@@ -123,12 +126,14 @@ SQField3DCartesian::SQField3DCartesian(const std::string& fname, const float mag
   //{ return (int((a.z-zmin)/zstepsize) + zsteps*(int((a.y-ymin)/ystepsize)) + ysteps*(int((a.x-xmin)/xstepsize))) < 
   //         (int((b.z-zmin)/zstepsize) + zsteps*(int((b.y-ymin)/ystepsize)) + ysteps*(int((b.x-xmin)/xstepsize))); })
 
-  std::cout << "  its demensions and ranges of the field: " << fpoints.size() << std::endl;
+#ifdef _DEBUG_ON
+  std::cout << "  its dimensions and ranges of the field: " << fpoints.size() << std::endl;
   std::cout << "    X: " << xsteps << " bins, " << xmin/cm << " cm -- " << xmax/cm << " cm, step size = " << xstepsize/cm << " cm." << std::endl;
   std::cout << "    Y: " << ysteps << " bins, " << ymin/cm << " cm -- " << ymax/cm << " cm, step size = " << ystepsize/cm << " cm." << std::endl;
   std::cout << "    Z: " << zsteps << " bins, " << zmin/cm << " cm -- " << zmax/cm << " cm, step size = " << zstepsize/cm << " cm." << std::endl;
 
   std::cout << "\n================= End Construct Mag Field ======================\n" << std::endl;
+#endif
 }
 
 SQField3DCartesian::~SQField3DCartesian()

--- a/packages/geom_svc/GeomSvc.cxx
+++ b/packages/geom_svc/GeomSvc.cxx
@@ -200,7 +200,6 @@ std::ostream& operator << (std::ostream& os, const Plane& plane)
         os << "\n";
         for(int i=0; i<9; ++i) os << std::setw(10) << std::setiosflags(std::ios::right) << plane.deltaW_module[i];
     }
-
     return os;
 }
 
@@ -416,7 +415,7 @@ void GeomSvc::initPlaneDirect() {
                              "xPrimeOffset,x0,y0,z0,planeWidth,planeHeight,theta_x,theta_y,theta_z from %s.Planes WHERE"
                              " detectorName LIKE 'D%%' OR detectorName LIKE 'H__' OR detectorName LIKE 'H____' OR "
                              "detectorName LIKE 'P____'";
-    sprintf(query, buf_planes, rc->get_CharFlag("Geometry").c_str());
+    //sprintf(query, buf_planes, rc->get_CharFlag("Geometry").c_str());
     TSQLResult* res = con->Query(query);
 
     unsigned int nRows = res->GetRowCount();
@@ -520,7 +519,9 @@ void GeomSvc::initPlaneDirect() {
             planes[i].z2 = planes[i].z0 + planes[i].cellWidth/2.;
         }
     }
-    cout << "GeomSvc: loaded basic spectrometer setup from geometry schema " << rc->get_CharFlag("Geometry") << endl;
+#ifdef _DEBUG_ON
+      cout << "GeomSvc: loaded basic spectrometer setup from geometry schema " << rc->get_CharFlag("Geometry") << endl;
+#endif
 
     //load the initial value in the planeOffsets table
     if(rc->get_BoolFlag("OnlineAlignment"))
@@ -532,7 +533,9 @@ void GeomSvc::initPlaneDirect() {
         res = con->Query(query);
 
         nRows = res->GetRowCount();
-        if(nRows >= nChamberPlanes) cout << "GeomSvc: loaded chamber alignment parameters from database: " << rc->get_CharFlag("Geometry") << endl;
+#ifdef _DEBUG_ON
+	  if(nRows >= nChamberPlanes) cout << "GeomSvc: loaded chamber alignment parameters from database: " << rc->get_CharFlag("Geometry") << endl;
+#endif
         for(unsigned int i = 0; i < nRows; ++i)
         {
             TSQLRow* row = res->Next();
@@ -565,7 +568,9 @@ void GeomSvc::initPlaneDirect() {
 void GeomSvc::initPlaneDbSvc() {
   using namespace std;
   const int run = 1; // todo: need adjustable in the future
-  cout << "GeomSvc:  Load the plane geometry info via DbSvc for run = " << run << "." << endl;
+#ifdef _DEBUG_ON
+    cout << "GeomSvc:  Load the plane geometry info via DbSvc for run = " << run << "." << endl;
+#endif
 
   GeomParamPlane* geom = new GeomParamPlane();
   geom->SetMapIDbyDB(run);
@@ -981,7 +986,9 @@ void GeomSvc::loadAlignment(const std::string& alignmentFile_chamber, const std:
             planes[i].resolution = resol;
         }
 
-        cout << "GeomSvc: loaded chamber alignment parameters from " << alignmentFile_chamber << endl;
+#ifdef _DEBUG_ON
+	  cout << "GeomSvc: loaded chamber alignment parameters from " << alignmentFile_chamber << endl;
+#endif
     }
     _align_chamber.close();
 
@@ -1001,11 +1008,13 @@ void GeomSvc::loadAlignment(const std::string& alignmentFile_chamber, const std:
             planes[i].deltaY = planes[i].deltaW*planes[i].sintheta;
             planes[i].update();
         }
-        cout << "GeomSvc: loaded hodoscope alignment parameters from " << alignmentFile_hodo << endl;
+#ifdef _DEBUG_ON
+	  cout << "GeomSvc: loaded hodoscope alignment parameters from " << alignmentFile_hodo << endl;
+#endif
     }
     else
     {
-        cout << "GeomSvc: failed to load hodoscope alignment parameters from " << alignmentFile_hodo << endl;
+      cout << "GeomSvc: failed to load hodoscope alignment parameters from " << alignmentFile_hodo << endl;
     }
     _align_hodo.close();
 
@@ -1039,7 +1048,9 @@ void GeomSvc::loadAlignment(const std::string& alignmentFile_chamber, const std:
             planes[i+1].deltaX = planes[i+1].deltaW*planes[i+1].costheta;
             planes[i+1].deltaY = planes[i+1].deltaW*planes[i+1].sintheta;
         }
-        cout << "GeomSvc: loaded prop. tube alignment parameters from " << alignmentFile_prop << endl;
+#ifdef _DEBUG_ON
+	  cout << "GeomSvc: loaded prop. tube alignment parameters from " << alignmentFile_prop << endl;
+#endif
     }
     else
     {
@@ -1071,7 +1082,9 @@ void GeomSvc::loadMilleAlignment(const std::string& alignmentFile_mille)
 
             //if(planes[i].resolution < RESOLUTION_DC) planes[i].resolution = RESOLUTION_DC;
         }
-        cout << "GeomSvc: loaded millepede-based alignment parameters from " << alignmentFile_mille << endl;
+#ifdef _DEBUG_ON
+	  cout << "GeomSvc: loaded millepede-based alignment parameters from " << alignmentFile_mille << endl;
+#endif
 
         for(int i = 1; i <= nChamberPlanes; i+=2)
         {
@@ -1120,7 +1133,9 @@ void GeomSvc::loadCalibration(const std::string& calibrationFile)
             if(planes[detectorID].rtprofile != NULL) delete planes[detectorID].rtprofile;
             if(nBin > 0) planes[detectorID].rtprofile = new TSpline3(getDetectorName(detectorID).c_str(), T, R, nBin, "b1e1");
         }
-        cout << "GeomSvc: loaded calibration parameters from " << calibrationFile << endl;
+#ifdef _DEBUG_ON
+	  cout << "GeomSvc: loaded calibration parameters from " << calibrationFile << endl;
+#endif
     }
     _cali_file.close();
 }

--- a/packages/geom_svc/RunParamBase.cc
+++ b/packages/geom_svc/RunParamBase.cc
@@ -102,8 +102,10 @@ void RunParamBase::ReadFromDB()
   }
   string name_schema =   SchemaName();
   string name_table  = MapTableName();
+#ifdef _DEBUG_ON
   cout << "Read channel map from "
        << name_schema << "." << name_table << ".\n";
+#endif
   //cout <<   "  Schema = " << name_schema
   //     << "\n  Table  = " << name_table << "\n";
 

--- a/packages/reco/ktracker/VertexFit.cxx
+++ b/packages/reco/ktracker/VertexFit.cxx
@@ -184,8 +184,9 @@ int VertexFit::InitRun(PHCompositeNode* topNode) {
 
 int VertexFit::process_event(PHCompositeNode* topNode) {
 
-  _recEvent->identify();
-
+  if (verbosity > 1){
+    _recEvent->identify();
+  }
   int ret = -99;
   try {
     ret = setRecEvent(_recEvent);

--- a/simulation/g4detectors/PHG4CylinderDetector.cc
+++ b/simulation/g4detectors/PHG4CylinderDetector.cc
@@ -78,7 +78,9 @@ void PHG4CylinderDetector::Construct(G4LogicalVolume *logicWorld)
 
 		TrackerMaterial = Target;
 
+#ifdef _DEBUG_ON
 		std::cout<< "DEBUG: " << TrackerMaterial << std::endl;
+#endif
 	} else if (params->get_string_param("material").find("Coil")
 			!= std::string::npos) {
 		G4double z;
@@ -107,7 +109,9 @@ void PHG4CylinderDetector::Construct(G4LogicalVolume *logicWorld)
 
 		TrackerMaterial = Coil;
 
+#ifdef _DEBUG_ON
 		std::cout<< "DEBUG: " << TrackerMaterial << std::endl;
+#endif
 	} else {
 		TrackerMaterial = G4Material::GetMaterial(
 				params->get_string_param("material"));
@@ -157,8 +161,10 @@ void PHG4CylinderDetector::Construct(G4LogicalVolume *logicWorld)
   rotm->rotateX(params->get_double_param("rot_x")*deg);
   rotm->rotateY(params->get_double_param("rot_y")*deg);
   rotm->rotateZ(params->get_double_param("rot_z")*deg);
+#ifdef _DEBUG_ON
   params->Print();
   rotm->print(std::cout);
+#endif
   cylinder_physi = new G4PVPlacement(rotm, G4ThreeVector(params->get_double_param("place_x") * cm,
                                                       params->get_double_param("place_y") * cm,
                                                       params->get_double_param("place_z") * cm),

--- a/simulation/g4detectors/PHG4TargetCoilV2Detector.cc
+++ b/simulation/g4detectors/PHG4TargetCoilV2Detector.cc
@@ -294,16 +294,18 @@ void PHG4TargetCoilV2Detector::Construct(G4LogicalVolume *logicWorld)
 	Coil->AddMaterial(G4Material::GetMaterial("G4_Nb"), 45 * perCent);
 	Coil->AddMaterial(G4Material::GetMaterial("G4_Ti"), 45 * perCent);
 	Coil->AddMaterial(G4Material::GetMaterial("G4_Cu"), 10 * perCent);
+#ifdef _DEBUG_ON
 	std::cout<< "PHG4TargetCoilV2Detector::Construct: " << Coil << std::endl;
-
+#endif
 	// 1/(0.6/7.87+0.2/7.18+0.15/8.902+0.05/10.22) = 7.95 g/cm3
 	G4Material* SS316L = new G4Material(name = "SS316L", density = 7.95*g/cm3, ncomponents = 4);
 	SS316L->AddMaterial(G4Material::GetMaterial("G4_Fe"), 60 * perCent);
 	SS316L->AddMaterial(G4Material::GetMaterial("G4_Cr"), 20 * perCent);
 	SS316L->AddMaterial(G4Material::GetMaterial("G4_Ni"), 15 * perCent);
 	SS316L->AddMaterial(G4Material::GetMaterial("G4_Mo"),  5 * perCent);
+#ifdef _DEBUG_ON
 	std::cout<< "PHG4TargetCoilV2Detector::Construct: " << SS316L << std::endl;
-
+#endif
   G4VisAttributes *cylinder_vis = new G4VisAttributes();
 	PHG4Utils::SetColour(cylinder_vis, "G4_He");
 	cylinder_vis->SetVisibility(true);
@@ -342,8 +344,10 @@ void PHG4TargetCoilV2Detector::Construct(G4LogicalVolume *logicWorld)
   rotm->rotateX(params->get_double_param("rot_x")*deg);
   rotm->rotateY(params->get_double_param("rot_y")*deg);
   rotm->rotateZ(params->get_double_param("rot_z")*deg);
+#ifdef _DEBUG_ON
   params->Print();
   rotm->print(std::cout);
+#endif
   cylinder_physi = new G4PVPlacement(
   		rotm,
   		G4ThreeVector(

--- a/simulation/g4detectors/SQG4DipoleMagnetDetector.cc
+++ b/simulation/g4detectors/SQG4DipoleMagnetDetector.cc
@@ -48,7 +48,9 @@ void SQG4DipoleMagnetDetector::Construct(G4LogicalVolume* logicWorld)
 {
   std::string dbfile = params->get_string_param("geomdb");
   std::string vName  = params->get_string_param("magname");
-  std::cout << "SQDipoleMagnet - begin construction of " << vName << " from " << dbfile << std::endl;
+  if(Verbosity() > 1){
+    std::cout << "SQDipoleMagnet - begin construction of " << vName << " from " << dbfile << std::endl;
+  }
 
   DbSvc* db_svc = new DbSvc(DbSvc::LITE, dbfile.c_str());
   std::unique_ptr<TSQLStatement> stmt;

--- a/simulation/g4gdml/PHG4GDMLWrite.cc
+++ b/simulation/g4gdml/PHG4GDMLWrite.cc
@@ -112,8 +112,9 @@ void PHG4GDMLWrite::UserinfoWrite(xercesc::DOMElement* gdmlElement)
 {
   if(auxList.size()>0)
   {
+#ifdef _DEBUG_ON
     G4cout << "PHG4GDML: Writing userinfo..." << G4endl;
-
+#endif
     userinfoElement = NewElement("userinfo");
     gdmlElement->appendChild(userinfoElement);
     AddAuxInfo(&auxList, userinfoElement);
@@ -172,8 +173,10 @@ G4Transform3D PHG4GDMLWrite::Write(const G4String& fname,
    SchemaLocation = setSchemaLocation;
    addPointerToName = refs;
 
+#ifdef _DEBUG_ON
    if (depth==0) { G4cout << "PHG4GDML: Writing '" << fname << "'..." << G4endl; }
    else   { G4cout << "PHG4GDML: Writing module '" << fname << "'..." << G4endl; }
+#endif
 
    if (FileExists(fname))
    {
@@ -266,6 +269,7 @@ G4Transform3D PHG4GDMLWrite::Write(const G4String& fname,
    delete myFormTarget;
    writer->release();
 
+#ifdef _DEBUG_ON
    if (depth==0)
    {
      G4cout << "PHG4GDML: Writing '" << fname << "' done !" << G4endl;
@@ -274,6 +278,7 @@ G4Transform3D PHG4GDMLWrite::Write(const G4String& fname,
    {
      G4cout << "PHG4GDML: Writing module '" << fname << "' done !" << G4endl;
    }
+#endif
 
    return R;
 }


### PR DESCRIPTION
Removing default printouts.

Log used to look like this (e.g. for 10 events with the electron A' signal sample):
[long.log](https://github.com/DarkQuest-FNAL/e1039-core/files/7339256/long.log)

Now log looks like this:
[short.log](https://github.com/DarkQuest-FNAL/e1039-core/files/7338846/short.log)