### PR TITLE
special treatment for the truth tracks with 24 hits...

### DIFF
--- a/simulation/g4dst/TruthNodeMaker.cc
+++ b/simulation/g4dst/TruthNodeMaker.cc
@@ -277,7 +277,14 @@ int TruthNodeMaker::process_event(PHCompositeNode* topNode)
       }
     }
 
-    if(rtrkid >= 0 && double(n_match)/double(ttrkid_hitidvec[ttrkid].size()) > m_matching_threshold) {
+    int ntruthhits = ttrkid_hitidvec[ttrkid].size();
+    if (ntruthhits > 18) {
+        // noticed in some cases the number of truth hits are 24
+        // (hitting DC1, DC2, DC3U and DU3D??)
+        // remove the extra hits when count matching
+        ntruthhits = 18;
+    }
+    if(rtrkid >= 0 && double(n_match)/double(ntruthhits) > m_matching_threshold) {
       trk->set_rec_track_id(rtrkid);
     }
   }


### PR DESCRIPTION
in some rare cases one muon could have 24 hits... maybe its because of some overlap between D3p and D3m? reco tracks has 18 hits at the most. 

so set the max truth hits to 18 for the gen-reco matching.